### PR TITLE
Add support for RoboMaster Dev A and Dev C Board (301 and 303)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ TARGETS	= \
 	px4fmu_bl \
 	px4fmuv2_bl \
 	px4fmuv3_bl \
+	robomaster_dev_a_bl \
+	robomaster_dev_c_bl \
 	px4fmuv4_bl \
 	px4fmuv4pro_bl \
 	px4fmuv5_bl \
@@ -115,6 +117,12 @@ px4fmuv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 px4fmuv3_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V3  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+robomaster_dev_a_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=ROBOMASTER_DEV_A  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+robomaster_dev_c_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=ROBOMASTER_DEV_C  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmuv4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/board_types.txt
+++ b/board_types.txt
@@ -4,6 +4,8 @@
 TARGET_HW_PX4_FMU_V1                    5
 TARGET_HW_PX4_FMU_V2                    9
 TARGET_HW_PX4_FMU_V3                    9 # same as FMU_V2
+TARGET_HW_ROBOMASTER_DEV_A            301
+TARGET_HW_ROBOMASTER_DEV_C            303
 TARGET_HW_PX4_FMU_V4                   11
 TARGET_HW_PX4_FMU_V4_PRO               13
 TARGET_HW_UVIFY_CORE		       20

--- a/hw_config.h
+++ b/hw_config.h
@@ -222,6 +222,121 @@
  */
 
 /****************************************************************************
+ * TARGET_HW_ROBOMASTER_DEV_A
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_ROBOMASTER_DEV_A)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_ROBOMASTER_DEV_A
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                0
+# define USBDEVICESTRING                "ROBOMASTER PX4 BL v1"
+# define USBPRODUCTID                   0x0011
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     301
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       12
+
+# define BOARD_PIN_LED_ACTIVITY         0               // no activity LED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO14
+# define BOARD_PORT_LEDS                GPIOF
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPFEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+// # define BOARD_USART                    USART1
+// # define BOARD_USART_CLOCK_REGISTER     RCC_APB2ENR
+// # define BOARD_USART_CLOCK_BIT          RCC_APB2ENR_USART1EN
+
+// # define BOARD_PORT_USART               GPIOD
+// # define BOARD_PORT_USART_AF            GPIO_AF7
+// # define BOARD_PIN_TX                   GPIO5
+// # define BOARD_PIN_RX                   GPIO6
+// # define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+// # define BOARD_USART_PIN_CLOCK_BIT      RCC_AHB1ENR_IOPDEN
+// # define SERIAL_BREAK_DETECT_DISABLED   1
+
+# define BOARD_USB_VBUS_SENSE_DISABLED
+
+/*
+ * Uncommenting this allows to force the bootloader through
+ * a PWM output pin. As this can accidentally initialize
+ * an ESC prematurely, it is not recommended. This feature
+ * has not been used and hence defaults now to off.
+ *
+ * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
+ * # define BOARD_FORCE_BL_PIN_IN          GPIO11
+ * # define BOARD_FORCE_BL_PORT            GPIOE
+ * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
+ * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
+ * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
+ */
+
+/****************************************************************************
+ * TARGET_HW_ROBOMASTER_DEV_C
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_ROBOMASTER_DEV_C)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_ROBOMASTER_DEV_C
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                0
+# define USBDEVICESTRING                "ROBOMASTER PX4 BL v1"
+# define USBPRODUCTID                   0x0011
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     303
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       12
+
+# define BOARD_PIN_LED_ACTIVITY         0               // no activity LED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO10
+# define BOARD_PORT_LEDS                GPIOH
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPHEN
+# define BOARD_LED_ON                   gpio_set
+# define BOARD_LED_OFF                  gpio_clear
+
+// # define BOARD_USART                    USART1
+// # define BOARD_USART_CLOCK_REGISTER     RCC_APB2ENR
+// # define BOARD_USART_CLOCK_BIT          RCC_APB2ENR_USART1EN
+
+// # define BOARD_PORT_USART               GPIOD
+// # define BOARD_PORT_USART_AF            GPIO_AF7
+// # define BOARD_PIN_TX                   GPIO5
+// # define BOARD_PIN_RX                   GPIO6
+// # define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+// # define BOARD_USART_PIN_CLOCK_BIT      RCC_AHB1ENR_IOPDEN
+// # define SERIAL_BREAK_DETECT_DISABLED   1
+
+# define BOARD_USB_VBUS_SENSE_DISABLED
+
+/*
+ * Uncommenting this allows to force the bootloader through
+ * a PWM output pin. As this can accidentally initialize
+ * an ESC prematurely, it is not recommended. This feature
+ * has not been used and hence defaults now to off.
+ *
+ * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
+ * # define BOARD_FORCE_BL_PIN_IN          GPIO11
+ * # define BOARD_FORCE_BL_PORT            GPIOE
+ * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
+ * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
+ * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
+ */
+
+
+/****************************************************************************
  * TARGET_HW_PX4_FMU_V4
  ****************************************************************************/
 
@@ -1297,7 +1412,7 @@
 #endif
 
 #if !defined(USBMFGSTRING)
-# define USBMFGSTRING "3D Robotics"
+# define USBMFGSTRING "NUS RoboMaster"
 #endif
 
 #if !defined(USBVENDORID)
@@ -1321,7 +1436,7 @@
 #if INTERFACE_USART
 #  if !defined(BOARD_PORT_USART_TX)
 #    define BOARD_PORT_USART_TX BOARD_PORT_USART
-#    define BOARD_PORT_USART_RX BOARD_PORT_USART
+#    define BOARD_PORT_USART_RX BOARD_PORT_USART // TODO: the PORT for RX and TX might be different
 #  endif
 #  if !defined(BOARD_USART_PIN_CLOCK_BIT_TX)
 #    define BOARD_USART_PIN_CLOCK_BIT_TX BOARD_USART_PIN_CLOCK_BIT


### PR DESCRIPTION
This PR is to fix the issue #1 , the key change is the following:
`# define BOARD_USB_VBUS_SENSE_DISABLED` , to disable the VBUS pin, which may prevent USB interface mounting process

In addition, this PR also enables LED BL light on both dev a and dev c. It is tested working on my Dev A board. @AndreWongZH  please help verify that this LED also works on Dev C

Pin assignment:
Dev A - F14 (Green, Active Low)
Dev C - H10 (Blue, Active High)